### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubi9
+FROM rhel9/ubi9
 COPY entrypoint.sh /entrypoint.sh
 RUN dnf install python3.9 -y
 RUN dnf install python3-pip -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi9
+FROM ubi9
 COPY entrypoint.sh /entrypoint.sh
 RUN dnf install python3.9 -y
 RUN dnf install python3-pip -y


### PR DESCRIPTION
I have observed the issue when using a self hosted github runner. I use self hosted runner as RHEL9 and by default the actions are running on a container on this self hosted runner.

Currently there is no "redhat/ubi9" shortname exist on RHEL system configurations. 

The files are;
  000-shortnames.conf
  001-rhel-shortnames.conf
  002-rhel-shortnames-overrides.conf

so it can not find any relation with that name and asking interaction with the error below;
```
STEP 1/11: FROM redhat/ubi9
  Error: creating build container: short-name resolution enforced but cannot prompt without a TTY
  Warning: Docker build failed with exit code 12[5](https://github.com/showroom-project/showroom-inventory/actions/runs/9993222819/job/27620117768#step:2:5), back off 8.961 seconds before retry.
```