### PR TITLE
Updating entrypoint.sh community.general

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,6 +58,7 @@ echo "scm_branch is $scm_branch"
 tee ansible.cfg << EOF
 [defaults]
 COLLECTIONS_PATHS = /root/.ansible/collections
+stdout_callback = default
 callback_result_format = yaml
 callbacks_enabled=ansible.posix.profile_tasks
 


### PR DESCRIPTION
Fixing 

ERROR! [DEPRECATED]: community.general.yaml has been removed. The plugin has been superseded by the option result_format=yaml in callback plugin ansible.builtin.default from ansible-core 2.13 onwards. This feature was removed from community.general in version 12.0.0. Please update your playbooks. Ansible Github Action Job has failed